### PR TITLE
Fixed coloring bug when there is no color field

### DIFF
--- a/doc/howToSetUpGalaxyOnOpenshift.txt
+++ b/doc/howToSetUpGalaxyOnOpenshift.txt
@@ -94,7 +94,7 @@ galaxy @ http://galaxy-pedees.rhcloud.com/ (uuid: 5611ccc02d52713b6000010c)
 9. Edit the start/stop scripts
 ------------------------------
 
-$ cd galaxy
+$ cd mygalaxy
 $ cat > .openshift/action_hooks/start <<EOF
 sh \$OPENSHIFT_DATA_DIR/source/galaxy/run.sh -—daemon
 EOF

--- a/visualizations/csg/templates/csg.mako
+++ b/visualizations/csg/templates/csg.mako
@@ -12,7 +12,6 @@
         ${h.javascript_link( app_root + 'dat.gui.min.js' )}
         ${h.javascript_link( app_root + 'three.min.js' )}
         ${h.javascript_link( app_root + 'Detector.js' )}
-        ${h.javascript_link( app_root + 'Lut.js' )}
         ${h.javascript_link( app_root + 'OrbitControls.js' )}
         ${h.javascript_link( app_root + 'PLYLoader.js' )}
         ${h.javascript_link( app_root + 'VTKLoader.js' )}

--- a/visualizations/csg/templates/csg.mako
+++ b/visualizations/csg/templates/csg.mako
@@ -12,6 +12,7 @@
         ${h.javascript_link( app_root + 'dat.gui.min.js' )}
         ${h.javascript_link( app_root + 'three.min.js' )}
         ${h.javascript_link( app_root + 'Detector.js' )}
+        ${h.javascript_link( app_root + 'Lut.js' )}
         ${h.javascript_link( app_root + 'OrbitControls.js' )}
         ${h.javascript_link( app_root + 'PLYLoader.js' )}
         ${h.javascript_link( app_root + 'VTKLoader.js' )}
@@ -83,7 +84,7 @@
                     }
 
                     var geometryHasColor = false;
-                    if ( geometry.type == "BufferGeometry" ) {
+                    if ( geometry.type == "BufferGeometry" && geometry.getAttribute( 'color' ) ) {
 
                         geometryHasColor = true;
                         // Color vertices
@@ -91,6 +92,7 @@
 
                     } else if ( geometry.type == "Geometry" ) { 
 
+                        // A geometry implies colors
                         geometryHasColor = true;
                         // Color Faces
                         surface[ 'vertexColors' ] = THREE.FaceColors;
@@ -99,6 +101,7 @@
 
                         // No color, use gui input
                         surface[ 'color' ] = new THREE.Color( 0xAAAAAA );
+                        surface[ 'vertexColors' ] = THREE.NoColors;
 
                     }
 


### PR DESCRIPTION
When there is no color, one has to set surface['vertexColors'] to THREE.NoColors.
