### PR TITLE
Fix due to API change in icqsol

### DIFF
--- a/tools/icqsol_solve_laplace/icqsol_solve_laplace.py
+++ b/tools/icqsol_solve_laplace/icqsol_solve_laplace.py
@@ -29,10 +29,11 @@ vtk_poly_data = shape_mgr.loadAsVtkPolyData(args.input)
 solver = icqsol_utils.get_laplace_solver(vtk_poly_data)
 
 # Set the output field names.
-solver.setNormalElectricFieldJumpName(args.output_jump_electric_field_name)
+solver.setResponseFieldName(args.output_jump_electric_field_name)
 
 # In place operation, vtk_poly_data will be modified.
-normalEJump = solver.computeNormalElectricFieldJump(potName=args.input_potential_name)
+solver.setSourceFieldName(args.input_potential_name)
+normalEJump = solver.computeResponseField()
 surfIntegral = shape_mgr.integrateSurfaceField(solver.getVtkPolyData(), args.output_jump_electric_field_name)
 print 'Surface integral of normal electric field jump: {0}'.format(surfIntegral)
 minVal, maxVal = shape_mgr.getFieldRange(solver.getVtkPolyData(), args.output_jump_electric_field_name)


### PR DESCRIPTION
@gregvonkuster 

The API in icqsol changed at some point to become more flexible, allowing more solvers to be added with time. For some reason the changes were not propagated back to galaxy-csg. This PR should fix the issue you found yesterday. The icqsol_solve_laplace.py test now passes for me. 

python ./icqsol_solve_laplace.py --input ./test-data/sphere.vtkbinary --input_file_format_and_type vtkbinary --input_dataset_type POLYDATA --input_potential_name v --output_jump_electric_field_name E_normal_jump --output ./out --output_vtk_type vtkascii
Surface integral of normal electric field jump: 7.6327832943e-16
min/max values of normal electric field jump: -9.71330243599/9.71330243599
